### PR TITLE
Add mozmill-2.0 support to MozBenchtester

### DIFF
--- a/BatchTester.py
+++ b/BatchTester.py
@@ -583,15 +583,6 @@ class BatchTest(object):
 
     try:
       mod = _get_hook(globalargs.get('hook'))
-      # TODO BenchTester should actually dynamically pick a free port, rather than
-      # taking it as a parameter.
-      s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-      try:
-        s.bind(('', 24242 + build.num))
-      except Exception, e:
-        raise Exception("Test error: jsbridge port %u unavailable" % (24242 + build.num,))
-      s.close()
-
       mod.run_tests(build, globalargs)
     except (Exception, KeyboardInterrupt) as e:
       err = "%s :: %s" % (type(e), e)

--- a/EnduranceTest.py
+++ b/EnduranceTest.py
@@ -9,15 +9,11 @@
 
 import BenchTester
 import os
-import sys
-import shutil
-import tempfile
 import re
 
 class EnduranceTest(BenchTester.BenchTest):
   def __init__(self, parent):
     BenchTester.BenchTest.__init__(self, parent)
-    parent.add_argument('--jsbridge_port', help="Port to use for jsbridge, so concurrent tests don't collide", default="24242")
     self.name = "EnduranceTest"
     self.parent = parent
 
@@ -26,10 +22,6 @@ class EnduranceTest(BenchTester.BenchTest):
     self.ready = True
     self.endurance_results = None
 
-    if 'jsbridge_port' in self.parent.args:
-      self.jsport = int(self.parent.args['jsbridge_port'])
-    else:
-      self.jsport = 24242
     return True
 
   def endurance_event(self, obj):
@@ -55,16 +47,22 @@ class EnduranceTest(BenchTester.BenchTest):
     self.info("Beginning endurance test '%s'" % testname)
 
     import mozmill
-    import mozrunner
-    import jsbridge
 
-    profdir = tempfile.mkdtemp("slimtest_profile")
-    self.info("Using temporary profile %s" % profdir)
-    #
     # Setup mozmill
-    #
-    self.info("Mozmill - setting up. Using jsbridge port %u" % (self.jsport,))
-    mozmillinst = mozmill.MozMill(jsbridge_port=self.jsport)
+    self.info("Mozmill - setting up.")
+
+    preferences = { 'startup.homepage_welcome_url': '',
+                    'startup.homepage_override_url': '' }
+    # Uncomment to enable jsbridge logging
+    #preferences['extensions.jsbridge.log'] = True
+    profile_args = dict(preferences=preferences)
+
+    runner_args = dict(binary=self.tester.binary)
+    # Uncomment to enable the browser's jsconsole
+    #runner_args['cmdargs'] = ['-jsconsole']
+
+    mozmillinst = mozmill.MozMill.create(runner_args=runner_args, profile_args=profile_args)
+
     mozmillinst.persisted['endurance'] = testvars
     mozmillinst.add_listener(self.endurance_event, eventType='mozmill.enduranceResults')
     # enduranceCheckpoint is used in slimtest's endurance version
@@ -72,61 +70,32 @@ class EnduranceTest(BenchTester.BenchTest):
     # which in turn inflate memory usage, which it's trying to measure)
     mozmillinst.add_listener(self.endurance_checkpoint, eventType='mozmill.enduranceCheckpoint')
 
-    profile = mozrunner.FirefoxProfile(binary=self.tester.binary,
-                                       profile=profdir,
-                                       addons=[jsbridge.extension_path, mozmill.extension_path],
-                                       # Don't open the first-run dialog, it loads a video
-                                       # and other things that can screw with benchmarks
-                                       preferences={'startup.homepage_welcome_url' : '',
-                                                    'startup.homepage_override_url' :''})
-    # HACK to work around mozrunner's broken stop/wait methods, which nuke all
-    # pids matching 'firefox' >= the child pid. This fixes concurrent tests.
-    # Bug735501 - fixed in mozmill 2.0+
-    class runnerwrap(mozrunner.FirefoxRunner):
-      def stop(self):
-        if not self.process_handler:
-          return
-        self.process_handler.kill()
-        self.process_handler.wait(timeout=10)
-      def wait(self, timeout=None):
-        """Wait for the browser to exit."""
-        self.process_handler.wait(timeout=timeout)
-
-    runner = runnerwrap(binary=self.tester.binary, profile=profile)
-    runner.cmdargs += ['-jsbridge', str(self.jsport)]
-
     # Add test
     testpath = os.path.join(*testvars['test'])
     if not os.path.exists(testpath):
       return self.error("Test '%s' specifies a test that doesn't exist: %s" % (testname, testpath))
-    mozmillinst.tests = [ testpath ]
+    # mozmill-2 requires an absolute path
+    testpath = os.path.abspath(testpath)
 
     # Run test
     self.endurance_results = None
-    self.info("Endurance - starting browser")
+    test_results = None;
     try:
-      mozmillinst.start(profile=runner.profile, runner=runner)
       self.info("Endurance - running test")
-      mozmillinst.run_tests(mozmillinst.tests)
-      successful = len(mozmillinst.fails) == 0
+      mozmillinst.run(tests=[ { "path": testpath } ])
+      test_results = mozmillinst.finish()
+      successful = len(test_results.fails) == 0
     except Exception, e:
       try:
-        mozmillinst.stop(fatal=True)
+        mozmillinst.finish(fatal=True)
       except: pass
-      shutil.rmtree(profdir)
       return self.error("Endurance test run failed -- %s: %s" % (type(e), e))
 
     self.info("Endurance - cleaning up")
     try:
-      # mozmillinst.stop() just calls stop_runner() -> cleanup(). stop_runner()
-      # without hard=True can hang (see XXX comment in mozmill), but passing
-      # hard=True can cause errors in cleanup(). However, since we nuke the
-      # profile ourselves, cleanup is unnecessary.
-      mozmillinst.stop_runner(timeout=10, close_bridge=True, hard=True)
+      mozmillinst.finish(fatal=True)
     except Exception, e:
       self.error("Failed to properly cleanup mozmill -- %s: %s" % (type(e), e))
-    finally:
-      shutil.rmtree(profdir)
 
     self.info("Endurance - saving results")
 
@@ -157,7 +126,7 @@ class EnduranceTest(BenchTester.BenchTest):
     if not self.tester.add_test_results(testname, results, successful):
       return self.error("Failed to save test results")
     if not successful:
-      fails = [y for x in mozmillinst.fails for y in x['fails']]
+      fails = [y for x in test_results.fails for y in x['fails']]
       return self.error("%u failures occured during test run: %s" % (len(fails), fails))
     self.info("Test '%s' complete" % testname)
     return True


### PR DESCRIPTION
This is based on the previous work of @Nephyrin. mozmill-2.0 lets us remove a fair amount of hackery related to jsbridge and profile cleanup.
